### PR TITLE
Change hero text

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -3,7 +3,7 @@ layout: home
 body-class: home
 permalink: /
 hero-image: /assets/img/aerial_capitol2.jpg
-hero-text: "Committed to the protection of civil liberties and privacy in the nation's efforts against terrorism."
+hero-text: "Working to ensure that efforts by the executive branch to protect the nation from terrorism are balanced with the need to protect privacy and civil liberties."
 hero-button-text: Learn more
 hero-button-link: /about/
 banner-heading:


### PR DESCRIPTION
Fixes #27. I think. Jen said to change the "white text in blue box on top right hand corner" and the only thing I see that's close to that is the hero unit, except it typically appears in the top-*left* rather than the top-right.

> ![hero-text](https://user-images.githubusercontent.com/124687/28798887-09308e10-7614-11e7-9920-3e2149e901e3.png)
