### PR TITLE
Add optional link checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 .sass-cache
 .DS_Store
+node_modules

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ If you ever decide that you no longer want to use Docker, run
 
 [Docker Community Edition]: https://www.docker.com/community-edition
 
+## Running the link checker
+
+To make sure the site doesn't have any 404s or other consistency issues,
+run:
+
+```
+npm install
+npm test
+```
+
 ## Upgrading USWDS
 
 This project uses the CSS and JavaScript from [U.S. Web Design System](https://standards.18f.gov).

--- a/_config.yml
+++ b/_config.yml
@@ -62,7 +62,7 @@ footer:
     - text: 'FOIA information'
       href: '/foia/'
     - text: 'Plain Writing Act'
-      href: '#'
+      href: 'http://www.plainlanguage.gov/pllaw/'
     - text: 'USA.gov'
       href: 'https://usa.gov'
     - text: 'OSC.gov'

--- a/_config.yml
+++ b/_config.yml
@@ -87,6 +87,8 @@ exclude:
   - LICENSE.md
   - README.md
   - legacy-site
+  - config
+  - package.json
 
 # Inititalize project and team collections
 collections:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="usa-footer usa-footer-big" role="contentinfo">
   <div class="usa-grid usa-footer-return-to-top">
-    <a href="#">Return to top</a>
+    <a href="#main">Return to top</a>
   </div>
   <div class="usa-footer-primary-section">
     <div class="usa-grid-full">
@@ -48,7 +48,7 @@
             <p><a href="tel:{{ site.footer.contact.phonenumber }}">{{ site.footer.contact.phonenumber }}</a></p>
           {% endif %}
           <p><a href="mailto:{{ site.footer.contact.email }}">{{ site.footer.contact.email }}</a></p>
-          <p><a href="#">FOIA information</a></p>
+          <p><a href="{{ site.baseurl }}/foia/">FOIA information</a></p>
         </address>
       </div>
       <div class="usa-footer-contact-links usa-width-one-fourth">

--- a/config/crawl.js
+++ b/config/crawl.js
@@ -1,0 +1,142 @@
+const path = require('path');
+const fs = require('fs');
+const cheerio = require('cheerio');
+const Crawler = require("simplecrawler");
+const chalk = require('chalk');
+
+const runServer = require('./static-server');
+
+// These pages incorporate content from other files in other repos, so
+// they should be considered "second class" by the link checker, and
+// only emit warnings on 404s rather than errors.
+const WARNING_PAGES = [
+  // e.g. '/foo/'
+];
+const WARNING = chalk.yellow('Warning');
+const ERROR = chalk.red('Error');
+const SITE_PATH = path.normalize(`${__dirname}/../_site`);
+
+function shouldFetch(item, referrerItem) {
+  if (item.path.match(/&quot;/)) {
+    // If a URL's path contains a literal `&quot;` in it, then it's
+    // almost guaranteed to be a false-positive that's actually
+    // in an example snippet of HTML in the docs, so ignore it.
+    return false;
+  } else if (referrerItem.path.match(/\.js$/)) {
+    // Just ignore anything gleaned from JS files for now, it's too likely
+    // that it's a false positive.
+    return false;
+  }
+
+  return true;
+}
+
+function findDuplicateIds($) {
+  const duplicates = [];
+  const idCounts = {};
+  const ids = $("[id]").each(function() {
+    const id = $(this).attr('id');
+
+    if (!(id in idCounts)) {
+      idCounts[id] = 0;
+    }
+    idCounts[id]++;
+
+    if (idCounts[id] === 2) {
+      duplicates.push(id);
+    }
+  });
+
+  return duplicates;
+}
+
+runServer().then(server => {
+  const crawler = new Crawler(`${server.url}/`);
+  const origDiscoverResources = crawler.discoverResources;
+  const referrers = {};
+  const notFound = [];
+  const duplicateIds = [];
+
+  crawler.discoverResources = function(buffer, item) {
+    if (/^text\/html/.test(item.stateData.contentType)) {
+      const $ = cheerio.load(buffer.toString("utf8"));
+      const ids = findDuplicateIds($);
+
+      if (ids.length) {
+        duplicateIds.push({ item, ids });
+      }
+    }
+    return origDiscoverResources.apply(this, arguments);
+  };
+
+  crawler.addFetchCondition((item, referrerItem, cb) => {
+    cb(null, shouldFetch(item, referrerItem));
+  });
+
+  crawler.maxDepth = 99;
+  crawler.interval = 1;
+  crawler.on("discoverycomplete", (item, resources) => {
+    resources.forEach(url => {
+      if (!(url in referrers)) {
+        referrers[url] = [];
+      }
+      referrers[url].push(item.path);
+    });
+  });
+  crawler.on("fetch404", (item, res) => {
+    notFound.push(item);
+  });
+  crawler.on("complete", () => {
+    server.httpServer.close(() => {
+      let errors = 0;
+      let warnings = 0;
+      const makeLabelForPaths = paths => {
+        const isWarning = paths.every(path => WARNING_PAGES.includes(path));
+        const label = isWarning ? WARNING : ERROR;
+
+        if (isWarning) {
+          warnings++;
+        } else {
+          errors++;
+        }
+
+        return label;
+      };
+
+      duplicateIds.forEach(({ item, ids }) => {
+        const label = makeLabelForPaths([ item.path ]);
+        console.log(`${label}: duplicate id attrs found at ${item.path}:`);
+        console.log(`  ${ids.join(', ')}`);
+      });
+
+      notFound.forEach(item => {
+        const refs = referrers[item.url];
+        const label = makeLabelForPaths(refs);
+
+        console.log(`${label}: 404 for ${item.path}`);
+        console.log(`  ${refs.length} referrer(s) including at least:`,
+                    refs.slice(0, 5));
+      });
+
+      WARNING_PAGES.forEach(path => {
+        if (!(`${server.url}${path}` in referrers)) {
+          console.log(`${ERROR}: ${path} was not visited!`);
+          console.log(`  If this is not an error, please remove the path ` +
+                      `from WARNING_PAGES.`);
+          errors++;
+        }
+      });
+
+      const success = errors === 0;
+
+      console.log(`${errors} error(s) and ${warnings} warning(s) found.`);
+      if (success) {
+        console.log(chalk.green(`Hooray!`));
+      } else {
+        console.log(chalk.red(`Alas.`));
+      }
+      process.exit(success ? 0 : 1);
+    });
+  });
+  crawler.start();
+});

--- a/config/static-server.js
+++ b/config/static-server.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const express = require('express');
+
+const app = express();
+
+const SITE_PATH = path.normalize(`${__dirname}/../_site`);
+
+if (fs.existsSync(SITE_PATH)) {
+  app.use(express.static(SITE_PATH));
+} else {
+  console.log(`Please build the site before running me.`);
+  process.exit(1);
+}
+
+module.exports = () => {
+  return new Promise((resolve, reject) => {
+    const server = app.listen(() => {
+      const hostname = os.hostname().toLowerCase();
+      const port = server.address().port;
+      resolve({
+        hostname,
+        port,
+        url: `http://${hostname}:${port}`,
+        httpServer: server,
+      });
+    });
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "pclob",
+  "version": "1.0.0",
+  "description": "This is a Jekyll project for the new Privacy and Civil Liberties Oversight Board (PCLOB) website.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node config/crawl.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/18F/pclob.git"
+  },
+  "author": "",
+  "license": "CC0-1.0",
+  "bugs": {
+    "url": "https://github.com/18F/pclob/issues"
+  },
+  "homepage": "https://github.com/18F/pclob#readme",
+  "dependencies": {
+    "chalk": "^2.1.0",
+    "cheerio": "^1.0.0-rc.2",
+    "express": "^4.15.4",
+    "simplecrawler": "^1.1.4"
+  }
+}


### PR DESCRIPTION
This fixes #44 by adding an *optional* link checker. It's optional right now because we still have a bunch of dead links.

It also ensures that all links to named anchors on the same page, e.g. `href="#boop"`, are valid.

This fixes all the `href="#"` ones in the base templates so the output isn't horribly spammy, though.

Code is largely taken from https://github.com/18F/web-design-standards-docs/pull/321 (well, the latest versions of the main files mentioned in that PR).