### PR TITLE
Center badges on label text

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -83,16 +83,6 @@ h1, h2, h3, h4, h5, h6 {
     background-color: $accent-color-light;
     border-radius: 100px;
   }
-  &.newsroom {
-    &:before {
-      padding: 3px 4px;
-      content: url('/assets/img/icon-newspaper.svg');
-    }
-  }
-  &.events:before {
-    padding: 0.25rem 0.35rem;
-    content: url('/assets/img/icon-calendar.svg');
-  }
 }
 
 .post {
@@ -103,6 +93,8 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .post--label {
+  position: relative;
+  padding-left: 30px; // this is to accommodate the "badge" icon: 25px wide + 5 spacing
   display: inline-block;
   border-right: 1px dotted #323a45;
   padding-right: 8px;
@@ -111,6 +103,21 @@ h1, h2, h3, h4, h5, h6 {
   + .post--date {
     padding-left: 2px;
   }
+  &.newsroom {
+    &:before {
+      position: absolute; // without this, the badge is slightly off-center from the text due to line-height (I think)
+      left: 0;
+      padding: 3px 4px;
+      content: url('/assets/img/icon-newspaper.svg');
+    }
+  }
+  &.events:before {
+    position: absolute; // without this, the badge is slightly off-center from the text due to line-height (I think)
+    left: 0;
+    padding: 0.25rem 0.35rem;
+    content: url('/assets/img/icon-calendar.svg');
+  }
+
 }
 
 .post--date {

--- a/pages/news-and-events.md
+++ b/pages/news-and-events.md
@@ -3,6 +3,11 @@ layout: page
 title: Events and press
 permalink: /newsroom/
 ---
+{% comment %}
+The news and events section uses Jekyll's built-in "post" type, which gives us
+some things for free that we couldn't get otherwise, like pagination. For more,
+see here: https://jekyllrb.com/docs/posts/
+{% endcomment %}
 
 {% for post in site.posts %}
 <div class="post">


### PR DESCRIPTION
Just some little tweaks to make the badges line up better with the labels on the events page.
<img width="329" alt="screen shot 2017-08-09 at 10 22 02 am" src="https://user-images.githubusercontent.com/509309/29132176-9bae8ba0-7cec-11e7-8482-a3943e6a344e.png">
