### PR TITLE
Add reports back to homepage

### DIFF
--- a/_includes/projects.html
+++ b/_includes/projects.html
@@ -1,28 +1,28 @@
-<div class="project-container">
-{% for project in site.projects %}
-  {% unless project.featured %}
+<div class="report-container">
+{% for report in site.reports %}
+  {% if report.featured %}
     <article class="card usa-width-one-third">
-      <a class="card-link" href="{{ project.url | prepend: site.baseurl }}" aria-hidden="true" tabindex="-1"></a>
-      {% if project.image_thumbnail %}
+      <a class="card-link" href="{{ report.url | prepend: site.baseurl }}" aria-hidden="true" tabindex="-1"></a>
+      {% if report.image_thumbnail %}
       <div class="card-image"
-           style="background-image: url({{ project.image_thumbnail | prepend: site.baseurl }});">
+           style="background-image: url({{ report.image_thumbnail | prepend: site.baseurl }});">
       </div>
-      {% elsif project.image %}
+      {% elsif report.image %}
       <div class="card-image"
-           style="background-image: url({{ project.image | prepend: site.baseurl }});">
+           style="background-image: url({{ report.image | prepend: site.baseurl }});">
       </div>
       {% endif %}
       <div class="card-banner">
         <h3 class="card-description">
-          <span>{{ project.title }}</span>
+          <span>{{ report.title }}</span>
         </h3>
-        <p class="card-summary">{{ project.description }}</p>
+        <p class="card-summary">{{ report.description }}</p>
       </div>
-      <a class="card-read" href="{{ project.url | prepend: site.baseurl }}">
+      <a class="card-read" href="{{ report.url | prepend: site.baseurl }}">
         Read more
-        <span class="usa-sr-only">about {{ project.title }}</span>
+        <span class="usa-sr-only">about {{ report.title }}</span>
       </a>
     </article>
-  {% endunless %}
+  {% endif %}
 {% endfor %}
 </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,7 +6,7 @@ layout: base
 <section class="usa-hero" style="background-position: 0% 0%; background-image: url('{{ site.feature_image | prepend: site.baseurl }}')">
   <div class="usa-grid">
     <div class="usa-hero-callout usa-section-dark">
-      <h2>{{ page.hero-text }}</h2>
+      <h3>{{ page.hero-text }}</h3>
       <a class="usa-button usa-button-big usa-button-secondary" href="#">Learn about what we do</a>
     </div>
   </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -26,7 +26,7 @@ layout: base
 
 
 <section class="usa-grid usa-section">
-    <h2>Popular resources</h2>
+    <h2>Featured reports</h2>
     {% include projects.html %}
 </section>
 

--- a/_reports/a2016-02_update-on-recommendations-215-702.md
+++ b/_reports/a2016-02_update-on-recommendations-215-702.md
@@ -5,6 +5,7 @@ description: All of the PCLOB’s 22 recommendations have been implemented in fu
 published_on: Feb. 5, 2016
 permalink: /projects/update-on-215-702/
 tags: project
+featured: true
 image:
 image-credit:
 documents:

--- a/_reports/b2014-08_report-on-702.md
+++ b/_reports/b2014-08_report-on-702.md
@@ -4,6 +4,7 @@ title: Report on the Surveillance Program Operated Pursuant to Section 702 of th
 description: The Section 702 program is extremely complex. The Board has found that certain aspects of the program’s implementation raise privacy concerns. The Board offers a series of policy recommendations to strengthen privacy safeguards and to address these concerns.
 permalink: /projects/report-702/
 tags: project
+featured: true
 image:
 image-credit:
 documents:

--- a/_reports/c2014-01_report-on-215.md
+++ b/_reports/c2014-01_report-on-215.md
@@ -2,9 +2,9 @@
 layout: project
 title: Report on the Telephone Records Program Conducted under Section 215 
 description: The NSA’s telephone records program is operated under an order issued by the FISA court pursuant to Section 215 of the Patriot Act, an order that is renewed approximately every ninety days. In response to congressional and presidential requests, the PCLOB undertook an in-depth study of the Section 215 and 702 programs as well as the operations of the FISA court.
-
 permalink: /reports/report-215/
 tags: project
+featured: true
 image:
 image-credit:
 documents:

--- a/_sass/_projects.scss
+++ b/_sass/_projects.scss
@@ -1,5 +1,5 @@
  @media screen and (min-width: 600px) {
-  .project-container {
+  .report-container {
     display: flex;
     flex-wrap: wrap;
     width: 102.5%;


### PR DESCRIPTION
The collection name just needed to be changed.

Also, sets the reports featured on the homepage to only show those with "featured' in their frontmatter. This will address what happens when there are more reports than the 3 spots on the page.

Changes the header to be more descriptive.

Adds flexbox back in to keep the cards the same height.