### PR TITLE
Rearrange press pages

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,12 +9,10 @@ layout: base
   </div>
   <div class="usa-width-three-fourths usa-content" style="margin-bottom: 1em">
     {{ content }}
-  </div>
 
   {% if page.links != empty %}
-  <aside class="usa-width-one-fourth">
     <h3>Related documents</h3>
-    <ul>
+    <ul class="usa-unstyled-list">
     {% for link in page.links %}
       {% assign first_char = link.url | truncate: 1, '' %}
       {% if first_char == '/' %}
@@ -22,9 +20,8 @@ layout: base
       {% else %}
         {% assign url = link.url %}
       {% endif %}
-      <li><a href="{{ url }}">{{ link.text }}</a></li>
+      <li><a class="usa-button document--download" href="{{ url }}">{{ link.text }} ({{ url | slice: -3,3 | upcase }})</a></li>
     {% endfor %}
     </ul>
-  </aside>
   {% endif %}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,7 +20,11 @@ layout: base
       {% else %}
         {% assign url = link.url %}
       {% endif %}
+      {% if {{ url | slice: -3,3 | upcase }} == 'PDF' %}
       <li><a class="usa-button document--download" href="{{ url }}">{{ link.text }} ({{ url | slice: -3,3 | upcase }})</a></li>
+      {% else %}
+      <li><a href="{{ url }}">{{ link.text }}</a></li>
+      {% endif %}
     {% endfor %}
     </ul>
   {% endif %}


### PR DESCRIPTION
This moves the "related documents" link to the bottom of the page and makes them a series of buttons. It also does a little Jekyll magic to pull the link type off the selected URL so we can indicate that it's a PDF if it is.
<img width="888" alt="screen shot 2017-08-10 at 12 51 47 pm" src="https://user-images.githubusercontent.com/509309/29186794-b1ac6e20-7dca-11e7-8027-b61737e2abd2.png">
<img width="829" alt="screen shot 2017-08-10 at 12 51 43 pm" src="https://user-images.githubusercontent.com/509309/29186795-b1ce071a-7dca-11e7-90ec-8c351f9d212f.png">
