### PR TITLE
[WIP] Add support for finding 404s when site base URL is not "/"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ similar to the one which Federalist builds your site on.
 1. Install [Docker Community Edition][].
 1. Clone the repository.
 1. Run `docker-compose up`.
-1. Visit the local site at [http://localhost:4000](http://localhost:4000)
+1. Visit the local site at [http://localhost:4000/dev/](http://localhost:4000/dev/)
 
 If you ever decide that you no longer want to use Docker, run
 `docker-compose down -v` to properly clean everything up.

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,17 @@
 # Site settings
 title: The Privacy and Civil Liberties Oversight Board
 description: Committed to the protection of civil liberties and privacy in the nation's efforts against terrorism.
-baseurl: "" # the subpath of your site, e.g. /blog
+
+# We're setting a baseurl here for development to ensure that
+# all our URLs on the actual site use {{ site.baseurl }} rather
+# than assuming the site is rooted at "/". This will ensure that
+# federalist branch builds, which are never rooted at "/", have no
+# 404s.
+#
+# During production, the "real" baseurl will be passed in through
+# the command-line, overriding the following value.
+baseurl: "/dev"
+
 url: "https://pclob.gov" # the base hostname & protocol for your site
 logo: /assets/img/Great_Seal_of_the_United_States.svg
 feature-image-large: /assets/img/featured-image-large.jpg # used by social sharing code as well as being the front page banner

--- a/config/crawl.js
+++ b/config/crawl.js
@@ -6,6 +6,7 @@ const chalk = require('chalk');
 
 const runServer = require('./static-server');
 
+const CRAWLER_START_PATH = process.env.CRAWLER_START_PATH || '/';
 // These pages incorporate content from other files in other repos, so
 // they should be considered "second class" by the link checker, and
 // only emit warnings on 404s rather than errors.
@@ -66,7 +67,7 @@ function findInvalidAnchors($) {
 }
 
 runServer().then(server => {
-  const crawler = new Crawler(`${server.url}/`);
+  const crawler = new Crawler(`${server.url}${CRAWLER_START_PATH}`);
   const origDiscoverResources = crawler.discoverResources;
   const referrers = {};
   const notFound = [];
@@ -111,7 +112,9 @@ runServer().then(server => {
       let errors = 0;
       let warnings = 0;
       const makeLabelForPaths = paths => {
-        const isWarning = paths.every(path => WARNING_PAGES.includes(path));
+        const isWarning = paths
+                          ? paths.every(path => WARNING_PAGES.includes(path))
+                          : false;
         const label = isWarning ? WARNING : ERROR;
 
         if (isWarning) {
@@ -140,8 +143,10 @@ runServer().then(server => {
         const label = makeLabelForPaths(refs);
 
         console.log(`${label}: 404 for ${item.path}`);
-        console.log(`  ${refs.length} referrer(s) including at least:`,
-                    refs.slice(0, 5));
+        if (refs) {
+          console.log(`  ${refs.length} referrer(s) including at least:`,
+                      refs.slice(0, 5));
+        }
       });
 
       WARNING_PAGES.forEach(path => {

--- a/config/crawl.js
+++ b/config/crawl.js
@@ -6,7 +6,6 @@ const chalk = require('chalk');
 
 const runServer = require('./static-server');
 
-const CRAWLER_START_PATH = process.env.CRAWLER_START_PATH || '/';
 // These pages incorporate content from other files in other repos, so
 // they should be considered "second class" by the link checker, and
 // only emit warnings on 404s rather than errors.
@@ -15,7 +14,6 @@ const WARNING_PAGES = [
 ];
 const WARNING = chalk.yellow('Warning');
 const ERROR = chalk.red('Error');
-const SITE_PATH = path.normalize(`${__dirname}/../_site`);
 
 function shouldFetch(item, referrerItem) {
   if (item.path.match(/&quot;/)) {
@@ -67,7 +65,7 @@ function findInvalidAnchors($) {
 }
 
 runServer().then(server => {
-  const crawler = new Crawler(`${server.url}${CRAWLER_START_PATH}`);
+  const crawler = new Crawler(`${server.url}${runServer.BASE_URL_PATH}/`);
   const origDiscoverResources = crawler.discoverResources;
   const referrers = {};
   const notFound = [];

--- a/config/static-server.js
+++ b/config/static-server.js
@@ -2,13 +2,19 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const express = require('express');
+const yaml = require('js-yaml');
 
 const app = express();
 
-const SITE_PATH = path.normalize(`${__dirname}/../_site`);
+const ROOT_DIR = path.normalize(path.join(__dirname, '..'));
+const JEKYLL_CONFIG = yaml.safeLoad(fs.readFileSync(path.join(
+  ROOT_DIR, '_config.yml')
+));
+const BASE_URL_PATH = JEKYLL_CONFIG.baseurl;
+const SITE_PATH = path.normalize(path.join(ROOT_DIR, '_site'));
 
 if (fs.existsSync(SITE_PATH)) {
-  app.use(express.static(SITE_PATH));
+  app.use(BASE_URL_PATH, express.static(SITE_PATH));
 } else {
   console.log(`Please build the site before running me.`);
   process.exit(1);
@@ -28,3 +34,5 @@ module.exports = () => {
     });
   });
 };
+
+Object.assign(module.exports, { BASE_URL_PATH });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chalk": "^2.1.0",
     "cheerio": "^1.0.0-rc.2",
     "express": "^4.15.4",
+    "js-yaml": "^3.10.0",
     "simplecrawler": "^1.1.4"
   }
 }


### PR DESCRIPTION
This changes the site base URL during development to `/dev`, to ensure that all links on the site work when the base URL isn't `/`.