### PR TITLE
Add developer mode ('devmode') to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ npm install
 npm test
 ```
 
+## Editing page content
+
+If you're ever on a page and want to make a change to its
+content, add `#devmode` to the end of the URL. You'll then
+see an "Edit this page" link at the bottom-right of the
+page; clicking on this will take you to a GitHub edit page
+where you can make changes.
+
 ## Upgrading USWDS
 
 This project uses the CSS and JavaScript from [U.S. Web Design System](https://standards.18f.gov).

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -63,6 +63,9 @@
             <li><a href="{{ href }}">{{ link.text }}</a></li>
           {% endfor %}
           </ul>
+          <ul id="dev-menu" class="usa-unstyled-list" style="display: none">
+            <li><a href="https://github.com/18F/pclob/edit/master/{{ page.path }}">Edit this page</a></li>
+          </ul>
         </div>
       </div>
     </div>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,6 +1,8 @@
 (function (document, window, $) {
   $(document).ready(function(){
     ajaxifyContactForm();
+    $(window).on('hashchange', showOrHideDeveloperMenu)
+      .trigger('hashchange');
   });
 
   function ajaxifyContactForm () {
@@ -23,5 +25,14 @@
       img.attr('src', url);
 
     });
+  }
+
+  function showOrHideDeveloperMenu() {
+    var devMenu = $('#dev-menu');
+    if (/devmode/.test(window.location.hash)) {
+      devMenu.fadeIn();
+    } else {
+      devMenu.fadeOut();
+    }
   }
 })(document, window, $);


### PR DESCRIPTION
@hbillings and I were talking about the possibility of adding an "Edit this page" or "Suggest changes to this page" link on every page that takes you to a GitHub edit page for the Markdown page corresponding to the page's content. One downside of this, however, is that it might confuse regular visitors, or make it seem like the whole site is a wiki.

@hbillings suggested toggling the display of such a link via something in the URL, so this PR adds support for a "developer mode" that shows a developer menu at the bottom-right of every page if `devmode` is present anywhere in the page's location hash. This basically means site admins can just add `#devmode` to the end of any URL to see "Edit this page" at the bottom-right of the page, then click on it to be taken to the page editor thingy.

## Limitations

* Right now "developer mode" just consists of the "Edit this page" link, but in the future we could add more links.

* At present the link only edits the version of the page on the master branch, so if users are on a Federalist branch build, they won't be taken to the version of that page on that build's branch. We can add support for this in the future by examining the base URL of the site, though, and interpreting it in the way that Federalist names branch build base URLs (though this will obviously break if Federalist ever decides to change the way they map base URLs to branch builds).
