### PR TITLE
fix baseurl var when site.baseurl is empty

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -5,11 +5,7 @@
 @charset "utf-8";
 
 // Our variables
-{% if site.baseurl != blank %}
-$baseurl:          {{ site.baseurl }};
-{% else %}
-$baseurl:          ''; //if this is local dev, just use a blank string
-{% endif %}
+$baseurl: '{{ site.baseurl }}';
 
 // Hero unit images
 $featured-image-large: '{{ site.feature-image-large }}';


### PR DESCRIPTION
Tested builds locally both with `baseurl: "/dev"` and `baseurl:` (ie, empty) in `_config.yml`